### PR TITLE
Fix session IsValid method to check for nil user agent

### DIFF
--- a/session.go
+++ b/session.go
@@ -64,12 +64,12 @@ func (s Session) IsValid(r *http.Request) bool {
 
 	os := true
 	if s.Agent.OS != "" {
-		os = s.Agent.OS == a.OS
+		os = a != nil && s.Agent.OS == a.OS
 	}
 
 	browser := true
 	if s.Agent.Browser != "" {
-		browser = s.Agent.Browser == a.Name
+		browser = a != nil && s.Agent.Browser == a.Name
 	}
 
 	return ip && os && browser

--- a/session_test.go
+++ b/session_test.go
@@ -39,6 +39,15 @@ func TestIsValid(t *testing.T) {
 			Session: ses,
 			Res:     false,
 		},
+		"Empty User-Agent": {
+			Req: func() *http.Request {
+				creq := httptest.NewRequest("GET", "http://example.com/", nil)
+				creq.RemoteAddr = req.RemoteAddr
+				return creq
+			}(),
+			Session: ses,
+			Res:     false,
+		},
 		"Invalid User-Agent browser": {
 			Req: func() *http.Request {
 				creq := httptest.NewRequest("GET", "http://example.com/", nil)


### PR DESCRIPTION
This fixes an issue where if we're trying to compare requests' empty User-Agent header with session that had one, it would cause a panic. This happens as empty User-Agent isn't parsed and returns nil user agent object, on which we're trying to access it's attributes. 